### PR TITLE
Fix: Avoid RuntimeError thrown by sub-folders without '_'

### DIFF
--- a/build.py
+++ b/build.py
@@ -53,6 +53,8 @@ def to_pinyin(s):
 
 
 def parse_poet(dir_name, root):
+    if root != sys.argv[1]:
+        return None  # Avoid RuntimeError thrown by subfolders without '_'
     split = dir_name.rindex('_')
     poet = {'n': dir_name[:split],
             'p': dir_name[split + 1:], 'c': 0, 'w': 0, 'dw': 0}


### PR DESCRIPTION
修改了一个可能引起运行时错误的代码：https://github.com/sheepzh/poetry-page/blob/5b7d9cd2fd03136bf848107be8acd905635aaa44/build.py#LL56C8-L56C8

```python
    split = dir_name.rindex('_')
```

`build.py`这个程序会扫描所有的子文件夹，当读取到一个不含有'_'的子文件夹时（如`data\张堃_zhangkun\33又1`），上述代码将会报错，此PR额外检查了此情况，且不会影响诗歌的解析。

补充说明：这个问题是因为win和*nix的文件目录不兼容导致的，`data/张堃_zhangkun/33又1\3转黑胶唱片.pt`中的`\`在win下被识别为一个文件夹分隔符。